### PR TITLE
fix #5005 : venus-auth ： contitue github action when error happened

### DIFF
--- a/.github/workflows/build_upload.yml
+++ b/.github/workflows/build_upload.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Zip Release
         uses: TheDoctor0/zip-release@0.6.0
+        continue-on-error: true
         with:
           filename: ${{steps.vars.outputs.artifact_name}}
           path: ./${{steps.vars.outputs.bin}}
@@ -113,6 +114,7 @@ jobs:
         id: release
         uses: ncipollo/release-action@v1
         if: ${{ steps.vars.outputs.pub_method=='pushRelease' }}
+        continue-on-error: true
         with:
           artifacts: ${{steps.vars.outputs.artifact_name}}
           tag: ${{ steps.vars.outputs.github_tag }}


### PR DESCRIPTION
## Linked Issue

fix https://github.com/filecoin-project/venus/issues/5005

## Propose Change

add 'continue-on-error: true' to two action 