### PR TITLE
opt: add default config for mysql

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,11 @@ func DefaultConfig() *Config {
 			HookSwitch: false,
 		},
 		DB: &DBConfig{
-			Type: Badger,
+			Type:         Badger,
+			MaxOpenConns: 64,
+			MaxIdleConns: 128,
+			MaxLifeTime:  120 * time.Second,
+			MaxIdleTime:  60 * time.Second,
 		},
 	}
 }


### PR DESCRIPTION
## 关联的Issues (Related Issues)
<!-- 列出本 PR 尝试解决或修复的 issues，或者描述本 PR 的目的。 -->
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

https://github.com/filecoin-project/venus/issues/5983

遇到 `invalid connection` 连接问题

```
2023/05/19 19:33:49 [31;1m/home/runner/work/venus-auth/venus-auth/storage/mysql.go:125 [35;1minvalid connection
[0m[33m[120012.231ms] [34;1m[rows:0][0m SELECT * FROM `token` WHERE token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiYWRtaW4iLCJwZXJtIjoiYWRtaW4iLCJleHQiOiIifQ.xxx' and is_deleted=0 LIMIT 1
[31mERRO[0m[2023-05-19T19:33:49+08:00] Error #01: get token: invalid connection      [31melapsed[0m=120012 [31mip[0m=10.123.1.31 [31mmethod[0m=verify [31mpreHost[0m="[]" [31mspanId[0m="[]" [31msvcName[0m="[]" [31mtoken[0m=

2023/05/19 19:33:49 [31;1m/home/runner/work/venus-auth/venus-auth/storage/mysql.go:125 [35;1minvalid connection
[0m[33m[120012.891ms] [34;1m[rows:0][0m SELECT * FROM `token` WHERE token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoiYWRtaW4iLCJwZXJtIjoiYWRtaW4iLCJleHQiOiIifQ.xxx' and is_deleted=0 LIMIT 1

2023/05/19 19:33:49 [32m/home/runner/work/venus-auth/venus-auth/storage/mysql.go:434 [33mSLOW SQL >= 200ms
[0m[31;1m[240021.561ms] [33m[rows:11][35m SELECT users.* FROM `signers` inner join users on signers.`signer` = '3vusi5aan25zrle52xtdaxuqf4z7on6dgcka2vfcr4a7vkbnjifqovnuhm5ddftm24yfvfosevugpxpgxxxxx' and users.`name` = signers.`user` and users.`is_deleted` = 0 WHERE `signers`.`deleted_at` IS NULL[0m
[mysql] 2023/05/19 19:33:49 packets.go:37: unexpected EOF
[mysql] 2023/05/19 19:33:49 packets.go:37: unexpected EOF

2023/05/19 19:33:49 [32m/home/runner/work/venus-auth/venus-auth/storage/mysql.go:434 [33mSLOW SQL >= 200ms
[0m[31;1m[240022.425ms] [33m[rows:3][35m SELECT users.* FROM `signers` inner join users on signers.`signer` = '3qhx2bxggdsdh6adrvnoehnknylyubkuh7nijzt766gd2ilmhwhakjppnepeiybgexutn5coxxxx' and users.`name` = signers.`user` and users.`is_deleted` = 0 WHERE `signers`.`deleted_at` IS NULL[0m
[31mERRO[0m[2023-05-19T19:33:49+08:00] Error #01: get token: invalid connection      [31melapsed[0m=120012 [31mip[0m=10.123.1.31 [31mmethod[0m=verify [31mpreHost[0m="[]" [31mspanId[0m="[]" [31msvcName[0m="[]" [31mtoken[0m=
```

配置中 `MaxLifeTime` 的为 0，则可能拿到 `MySQL` 已经关闭的连接，所以增加一些默认的超时时间。
```
[DB]
  Type = "mysql"
  DSN = "xxxxx"
  MaxOpenConns = 0
  MaxIdleConns = 0
  MaxLifeTime = 0
  MaxIdleTime = 0
```

## 改动 (Proposed Changes)
<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->


## 附注 (Additional Info)
<!-- 需要额外了解的信息 -->
<!-- callouts, links to documentation, and etc-->

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
